### PR TITLE
Mac file handler

### DIFF
--- a/native-launchers-maven-plugin/src/main/java/us/hebi/launchers/BaseConfig.java
+++ b/native-launchers-maven-plugin/src/main/java/us/hebi/launchers/BaseConfig.java
@@ -20,6 +20,7 @@
 
 package us.hebi.launchers;
 
+import org.apache.maven.execution.BuildSuccess;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
@@ -29,6 +30,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Florian Enner
@@ -118,11 +120,29 @@ abstract class BaseConfig extends AbstractMojo {
         @Parameter
         protected Boolean cocoa;
 
+        /**
+         * Enables capturing macOS Apple Events (e.g., "Open With" or dropping files on the dock).
+         * When true, file paths are redirected to the main method via background threads,
+         * emulating the multi-process behavior of Windows/Linux.
+         */
+        @Parameter(property = "cocoaFileHandler", defaultValue = "false")
+        protected boolean cocoaFileHandler = false;
+
         @Parameter
         protected List<String> jvmArgs = Collections.emptyList();
 
         public boolean enableCocoa() {
             return (cocoa != null && cocoa) || !console;
+        }
+
+        public boolean enableCocoaFileHandler() {
+            return enableCocoa() && cocoaFileHandler;
+        }
+
+        public Optional<String> getUserModelId() {
+            return Optional.ofNullable(userModelId)
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty());
         }
 
         public String getMainClass() {
@@ -135,6 +155,10 @@ abstract class BaseConfig extends AbstractMojo {
 
         public String getCFileName() {
             return name + ".c";
+        }
+
+        public String getOutputName() {
+            return Utils.isWindows() ? name + ".exe" : name;
         }
 
         public String getSymbolName() {

--- a/native-launchers-maven-plugin/src/main/resources/us/hebi/launchers/templates/AppDelegate.m
+++ b/native-launchers-maven-plugin/src/main/resources/us/hebi/launchers/templates/AppDelegate.m
@@ -28,9 +28,9 @@
 #import <stdatomic.h>
 
 #ifdef DEBUG
-#define LOG_DEBUG(message) NSLog(message);
+#define LOG_DEBUG(message, ...) NSLog(message, ##__VA_ARGS__);
 #else
-#define LOG_DEBUG(message)
+#define LOG_DEBUG(message, ...)
 #endif
 
 typedef int (*main_callback_t)(int argc, char **argv);

--- a/native-launchers-maven-plugin/src/main/resources/us/hebi/launchers/templates/launcher_dynamic.c
+++ b/native-launchers-maven-plugin/src/main/resources/us/hebi/launchers/templates/launcher_dynamic.c
@@ -181,7 +181,9 @@ int main_entry_point(int argc, char** argv) {
         return 1;
     }
 
+    PRINT_DEBUG("Creating Java args[%d]",arrayLength);
     for (int i = 0; i < arrayLength; i++) {
+        PRINT_DEBUG("  args[%d]=%s",i, argv[i+1]);
         jstring str = (*env)->NewStringUTF(env, argv[i + 1]);
         if (str == NULL) {
             PRINT_ERROR("Failed to create string for argument %d", i);

--- a/native-launchers-maven-plugin/src/main/resources/us/hebi/launchers/templates/launcher_dynamic.c
+++ b/native-launchers-maven-plugin/src/main/resources/us/hebi/launchers/templates/launcher_dynamic.c
@@ -136,7 +136,7 @@ int main_entry_point(int argc, char** argv) {
 
     PRINT_DEBUG("Adding vm options:");
     for (int i=0; i < nOptions; i++) {
-        PRINT_DEBUG(options[i].optionString);
+        PRINT_DEBUG("%s", options[i].optionString);
     }
 
     // Init struct


### PR DESCRIPTION
Added file handling for macOS (Cocoa) apps that emulate the behavior of Windows/Linux (launch new process with filename as argument). This was added because the AWT handler does not work in native-image, and this is a straight forward way to consume from Java.